### PR TITLE
cci flow: assign "manage" permission set

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -17,3 +17,13 @@ tasks:
         options:
             path: robot/Membership-Management/tests
             output: robot/Membership-Management/doc/Membership-Management_tests.html
+
+
+flows:
+    dev_org:
+        steps:
+            3: 
+                task: assign_permission_sets 
+                options: 
+                    api_names: Manage_Memberships
+


### PR DESCRIPTION
The "update Admin profile" task doesn't seem to entirely provide access, specifically to OpportunityLineItem.Membership__c.
This PR assigns the Manage Memberships permission set to the running user as part of `cci flow run dev_org`