### PR TITLE
Add/update final descriptions and help text

### DIFF
--- a/force-app/main/default/objects/Contact/fields/First_Membership_Start_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/First_Membership_Start_Date__c.field-meta.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>First_Membership_Start_Date__c</fullName>
+    <description>The start date of the oldest membership associated with this contact</description>
     <externalId>false</externalId>
-    <inlineHelpText>The start date of the oldest Membership associated to this Contact</inlineHelpText>
+    <inlineHelpText>Select the start date of the oldest membership associated with this contact</inlineHelpText>
     <label>First Membership Start Date</label>
     <required>false</required>
-    <trackFeedHistory>false</trackFeedHistory>
     <type>Date</type>
 </CustomField>

--- a/force-app/main/default/objects/Contact/fields/Last_Membership_Start_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/Last_Membership_Start_Date__c.field-meta.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Last_Membership_Start_Date__c</fullName>
+    <description>The start date of the most recent membership associated with this contact</description>
     <externalId>false</externalId>
-    <inlineHelpText>The start date of the most recent Membership associated with this Contact</inlineHelpText>
+    <inlineHelpText>Select the start date of the most recent membership associated with this contact</inlineHelpText>
     <label>Last Membership Start Date</label>
     <required>false</required>
-    <trackFeedHistory>false</trackFeedHistory>
     <type>Date</type>
 </CustomField>

--- a/force-app/main/default/objects/Contact/fields/Membership_End_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/Membership_End_Date__c.field-meta.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Membership_End_Date__c</fullName>
+    <description>Displays the greatest end date of any membership associated with this contact</description>
     <externalId>false</externalId>
-    <inlineHelpText>The greatest End Date of any Membership Contact Role associated with this Contact</inlineHelpText>
+    <inlineHelpText>Select the greatest end date of any membership associated with this contact</inlineHelpText>
     <label>Membership End Date</label>
     <required>false</required>
-    <trackFeedHistory>false</trackFeedHistory>
     <type>Date</type>
 </CustomField>

--- a/force-app/main/default/objects/Contact/fields/Membership_Status__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/Membership_Status__c.field-meta.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Membership_Status__c</fullName>
+    <description>Contact membership status options: Current, Lapsed, Former, and Renewal.</description>
     <externalId>false</externalId>
-    <inlineHelpText>The Contact&apos;s current memberships status</inlineHelpText>
+    <inlineHelpText>Select the current membership status. This should match the type of the most recent active.</inlineHelpText>
     <label>Membership Status</label>
     <required>false</required>
-    <trackFeedHistory>false</trackFeedHistory>
     <type>Picklist</type>
     <valueSet>
         <restricted>true</restricted>

--- a/force-app/main/default/objects/Contact/fields/Membership_Type__c.field-meta.xml
+++ b/force-app/main/default/objects/Contact/fields/Membership_Type__c.field-meta.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Membership_Type__c</fullName>
+    <description>Contact membership type options based on the most recent active membership: Individual, Household, and Corporate.</description>
     <externalId>false</externalId>
-    <inlineHelpText>This Contact&apos;s current Membership Type, based on the most recent active Membership</inlineHelpText>
+    <inlineHelpText>Select the current membership type. This should match the type of the most recent active Memberhip.</inlineHelpText>
     <label>Membership Type</label>
     <required>false</required>
-    <trackFeedHistory>false</trackFeedHistory>
     <type>Picklist</type>
     <valueSet>
         <restricted>true</restricted>

--- a/force-app/main/default/objects/Membership_Contact_Role__c/fields/Contact__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership_Contact_Role__c/fields/Contact__c.field-meta.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Contact__c</fullName>
+    <description>The contact record tied to the membership</description>
     <externalId>false</externalId>
     <inlineHelpText>Select a contact for this membership contact role</inlineHelpText>
     <label>Contact</label>

--- a/force-app/main/default/objects/Membership_Contact_Role__c/fields/Does_Not_Expire__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership_Contact_Role__c/fields/Does_Not_Expire__c.field-meta.xml
@@ -2,8 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Does_Not_Expire__c</fullName>
     <defaultValue>false</defaultValue>
+    <description>Indicates that the contact&apos;s  role on this membership does not expire. This should match the settings on the membership.</description>
     <externalId>false</externalId>
-    <inlineHelpText>This Contact&apos;s Membership does not expire. Defaults to the expiry setting on the Membership.</inlineHelpText>
+    <inlineHelpText>&quot;Check this box if the contact&apos;s role on this membership does not expire.&quot;</inlineHelpText>
     <label>Does Not Expire</label>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/Membership_Contact_Role__c/fields/End_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership_Contact_Role__c/fields/End_Date__c.field-meta.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>End_Date__c</fullName>
+    <description>The date on which the contact&apos;s role on the membership ends (if applicable)</description>
     <externalId>false</externalId>
+    <inlineHelpText>Add the contact role&apos;s end date (if applicable). If this contact role doesn&apos;t have an end date, select the Does Not Expire checkbox to save the record.</inlineHelpText>
     <label>End Date</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Membership_Contact_Role__c/fields/Is_Primary__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership_Contact_Role__c/fields/Is_Primary__c.field-meta.xml
@@ -2,9 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Is_Primary__c</fullName>
     <defaultValue>false</defaultValue>
-    <description>This membership contact is the primary contact for the membership</description>
+    <description>Indicates that this is the primary contact for this membership</description>
     <externalId>false</externalId>
-    <inlineHelpText>Check if this is the primary contact for this membership</inlineHelpText>
+    <inlineHelpText>Check this box if this is the primary contact for this membership</inlineHelpText>
     <label>Primary</label>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/Membership_Contact_Role__c/fields/Membership__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership_Contact_Role__c/fields/Membership__c.field-meta.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Membership__c</fullName>
-    <description>The Membership record to which the Member belongs</description>
+    <description>The membership record to which the membership contact role is tied to</description>
     <externalId>false</externalId>
-    <inlineHelpText>The Membership record to which the Member belongs</inlineHelpText>
+    <inlineHelpText>Select a membership for this membership contact role</inlineHelpText>
     <label>Membership</label>
     <referenceTo>Membership__c</referenceTo>
     <relationshipLabel>Membership Contact Roles</relationshipLabel>

--- a/force-app/main/default/objects/Membership_Contact_Role__c/fields/Role__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership_Contact_Role__c/fields/Role__c.field-meta.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Role__c</fullName>
+    <description>How the contact is related to the membership: Named Member, Additional Member, Spouse, Household Member, Employee</description>
     <externalId>false</externalId>
+    <inlineHelpText>Select the contact&apos;s role for this membership</inlineHelpText>
     <label>Role</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Membership_Contact_Role__c/fields/Start_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership_Contact_Role__c/fields/Start_Date__c.field-meta.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Start_Date__c</fullName>
+    <description>The date on which the contact&apos;s role on this membership begins</description>
     <externalId>false</externalId>
+    <inlineHelpText>Add the contact role&apos;s start date</inlineHelpText>
     <label>Start Date</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Membership_Contact_Role__c/fields/Status__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership_Contact_Role__c/fields/Status__c.field-meta.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Status__c</fullName>
+    <description>Membership contact role status options: Current, Lapsed, Former, and Renewal</description>
     <externalId>false</externalId>
+    <inlineHelpText>Select a membership contact role status. This should match the Membership status</inlineHelpText>
     <label>Status</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Membership_Contact_Role__c/fields/Type__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership_Contact_Role__c/fields/Type__c.field-meta.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Type__c</fullName>
+    <description>Membership contact role type options: Individual, Household, and Corporate.</description>
     <externalId>false</externalId>
-    <inlineHelpText>The Type of Membership this Contact has</inlineHelpText>
+    <inlineHelpText>Select a membership contact role type. This should match the Membership type.</inlineHelpText>
     <label>Type</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Membership__c/fields/Account__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership__c/fields/Account__c.field-meta.xml
@@ -2,8 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Account__c</fullName>
     <deleteConstraint>SetNull</deleteConstraint>
+    <description>The account this membership is tied to</description>
     <externalId>false</externalId>
-    <inlineHelpText>Select the account this membership is tied to</inlineHelpText>
+    <inlineHelpText>Select or create the account this membership is tied to</inlineHelpText>
     <label>Account</label>
     <referenceTo>Account</referenceTo>
     <relationshipLabel>Memberships</relationshipLabel>

--- a/force-app/main/default/objects/Membership__c/fields/Does_Not_Expire__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership__c/fields/Does_Not_Expire__c.field-meta.xml
@@ -2,7 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Does_Not_Expire__c</fullName>
     <defaultValue>false</defaultValue>
+    <description>Check this box on memberships without an end date</description>
     <externalId>false</externalId>
+    <inlineHelpText>Check this box if this membership has no end date</inlineHelpText>
     <label>Does Not Expire</label>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/Membership__c/fields/End_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership__c/fields/End_Date__c.field-meta.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>End_Date__c</fullName>
+    <description>The date on which the membership ends (if applicable)</description>
     <externalId>false</externalId>
+    <inlineHelpText>Add the membership end date (if applicable). If this membership doesn&apos;t have an end date, select the Does Not Expire checkbox to save the record.</inlineHelpText>
     <label>End Date</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Membership__c/fields/Opportunity__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership__c/fields/Opportunity__c.field-meta.xml
@@ -2,7 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Opportunity__c</fullName>
     <deleteConstraint>SetNull</deleteConstraint>
+    <description>The opportunity that this membership is tied to</description>
     <externalId>false</externalId>
+    <inlineHelpText>Select or create an opportunity to add this membership to</inlineHelpText>
     <label>Opportunity</label>
     <referenceTo>Opportunity</referenceTo>
     <relationshipLabel>Memberships</relationshipLabel>

--- a/force-app/main/default/objects/Membership__c/fields/Origin__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership__c/fields/Origin__c.field-meta.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Origin__c</fullName>
+    <description>Membership origin options: New, Renewed, and Reacquired.</description>
     <externalId>false</externalId>
+    <inlineHelpText>Select the membership origin</inlineHelpText>
     <label>Origin</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Membership__c/fields/Primary_Contact__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership__c/fields/Primary_Contact__c.field-meta.xml
@@ -2,8 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Primary_Contact__c</fullName>
     <deleteConstraint>SetNull</deleteConstraint>
+    <description>The primary contact for this membership</description>
     <externalId>false</externalId>
-    <inlineHelpText>Select the primary contact for this membership</inlineHelpText>
+    <inlineHelpText>Select or create a contact who will be the primary contact for this membership</inlineHelpText>
     <label>Primary Contact</label>
     <referenceTo>Contact</referenceTo>
     <relationshipLabel>Memberships</relationshipLabel>

--- a/force-app/main/default/objects/Membership__c/fields/Primary__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership__c/fields/Primary__c.field-meta.xml
@@ -2,8 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Primary__c</fullName>
     <defaultValue>false</defaultValue>
-    <description>Indicates primary membership.</description>
+    <description>Indicates that this is the primary membership for this account</description>
     <externalId>false</externalId>
+    <inlineHelpText>Check this box if this is the primary membership for this account</inlineHelpText>
     <label>Primary</label>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>

--- a/force-app/main/default/objects/Membership__c/fields/Product__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership__c/fields/Product__c.field-meta.xml
@@ -2,7 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Product__c</fullName>
     <deleteConstraint>SetNull</deleteConstraint>
+    <description>Product(s) that are tied to this membership</description>
     <externalId>false</externalId>
+    <inlineHelpText>Select membership product(s)</inlineHelpText>
     <label>Product</label>
     <referenceTo>Product2</referenceTo>
     <relationshipLabel>Memberships</relationshipLabel>

--- a/force-app/main/default/objects/Membership__c/fields/Start_Date__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership__c/fields/Start_Date__c.field-meta.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Start_Date__c</fullName>
+    <description>The date on which the membership starts</description>
     <externalId>false</externalId>
+    <inlineHelpText>Add the membership start date</inlineHelpText>
     <label>Start Date</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Membership__c/fields/Status__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership__c/fields/Status__c.field-meta.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Status__c</fullName>
+    <description>Membership status options: Current, Lapsed, Former, and Renewal.</description>
     <externalId>false</externalId>
+    <inlineHelpText>Select a membership status</inlineHelpText>
     <label>Status</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Membership__c/fields/Type__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership__c/fields/Type__c.field-meta.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Type__c</fullName>
+    <description>Membership type options: Individual, Household, and Corporate.</description>
     <externalId>false</externalId>
+    <inlineHelpText>Select a membership type</inlineHelpText>
     <label>Type</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Product2/Product2.object-meta.xml
+++ b/force-app/main/default/objects/Product2/Product2.object-meta.xml
@@ -85,6 +85,20 @@
         <type>Default</type>
     </actionOverrides>
     <actionOverrides>
+        <actionName>PreviewProductAction</actionName>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>PreviewProductAction</actionName>
+        <formFactor>Large</formFactor>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
+        <actionName>PreviewProductAction</actionName>
+        <formFactor>Small</formFactor>
+        <type>Default</type>
+    </actionOverrides>
+    <actionOverrides>
         <actionName>SaveEdit</actionName>
         <type>Default</type>
     </actionOverrides>

--- a/force-app/main/default/objects/Product2/fields/Downgrade_Path__c.field-meta.xml
+++ b/force-app/main/default/objects/Product2/fields/Downgrade_Path__c.field-meta.xml
@@ -2,7 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Downgrade_Path__c</fullName>
     <deleteConstraint>SetNull</deleteConstraint>
+    <description>List the downgrade options for this product with descriptions here</description>
     <externalId>false</externalId>
+    <inlineHelpText>Select a downgrade path product</inlineHelpText>
     <label>Downgrade Path</label>
     <referenceTo>Product2</referenceTo>
     <relationshipLabel>Products (Downgrade Path)</relationshipLabel>

--- a/force-app/main/default/objects/Product2/fields/Grace_Period__c.field-meta.xml
+++ b/force-app/main/default/objects/Product2/fields/Grace_Period__c.field-meta.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Grace_Period__c</fullName>
-    <description>The number of days after an expiration that a membership status will be updated to &quot;Lapsed&quot; before changing to &quot;Expired&quot;.</description>
+    <description>Number of days after an expiration date that the membership status will be set to &quot;Lapsed&quot; before changing to &quot;Expired&quot;</description>
     <externalId>false</externalId>
+    <inlineHelpText>This is the amount of days this product&apos;s status will be set to &quot;Lapsed&quot; before it changes to &quot;Expired&quot;</inlineHelpText>
     <label>Grace Period (Days)</label>
     <precision>18</precision>
     <required>false</required>

--- a/force-app/main/default/objects/Product2/fields/Renewal_Option__c.field-meta.xml
+++ b/force-app/main/default/objects/Product2/fields/Renewal_Option__c.field-meta.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Renewal_Option__c</fullName>
+    <description>Renewal options for this product: One-Time, Fixed-Term, Renewable, and Lifetime</description>
     <externalId>false</externalId>
+    <inlineHelpText>Select a renewal option for this product</inlineHelpText>
     <label>Renewal Option</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Product2/fields/Term_Unit__c.field-meta.xml
+++ b/force-app/main/default/objects/Product2/fields/Term_Unit__c.field-meta.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Term_Unit__c</fullName>
+    <description>Specifies whether the term is calculated in days, weeks, months, or years. Tied to Term.</description>
     <externalId>false</externalId>
+    <inlineHelpText>Select a term unit to define a term length for this product</inlineHelpText>
     <label>Term Unit</label>
     <required>false</required>
     <trackHistory>false</trackHistory>

--- a/force-app/main/default/objects/Product2/fields/Term__c.field-meta.xml
+++ b/force-app/main/default/objects/Product2/fields/Term__c.field-meta.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Term__c</fullName>
+    <description>Tied to Term Unit to identify the length of the membership</description>
     <externalId>false</externalId>
+    <inlineHelpText>This indicates the term lengths of the product, based on the selected Term Unit.</inlineHelpText>
     <label>Term</label>
     <precision>18</precision>
     <required>false</required>

--- a/force-app/main/default/objects/Product2/fields/Upgrade_Path__c.field-meta.xml
+++ b/force-app/main/default/objects/Product2/fields/Upgrade_Path__c.field-meta.xml
@@ -2,7 +2,9 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Upgrade_Path__c</fullName>
     <deleteConstraint>SetNull</deleteConstraint>
+    <description>List the upgrade options for this product with descriptions here</description>
     <externalId>false</externalId>
+    <inlineHelpText>Select an upgrade path product</inlineHelpText>
     <label>Upgrade Path</label>
     <referenceTo>Product2</referenceTo>
     <relationshipLabel>Upgrade_from</relationshipLabel>


### PR DESCRIPTION
Account object descriptions and help text will be updated in a separate task due to past system issues.

# Critical Changes

- [x] Disabled feed tracking on the Account, Contact, and Opportunity objects.

# Changes

- [x] Added/updated descriptions and help text on fields on the Membership, Membership Contact Role, Contact, and Product objects.

# Issues Closed